### PR TITLE
Check for ProtectedAttributes

### DIFF
--- a/app/models/scorecard/level.rb
+++ b/app/models/scorecard/level.rb
@@ -3,7 +3,7 @@ class Scorecard::Level < ActiveRecord::Base
 
   belongs_to :user, polymorphic: true
 
-  if Rails.version.to_s < '4.0.0'
+  if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
     attr_accessible :amount, :user
   end
 

--- a/app/models/scorecard/point.rb
+++ b/app/models/scorecard/point.rb
@@ -4,7 +4,7 @@ class Scorecard::Point < ActiveRecord::Base
   belongs_to :user,     polymorphic: true
   belongs_to :gameable, polymorphic: true
 
-  if Rails.version.to_s < '4.0.0'
+  if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
     attr_accessible :context, :identifier, :amount, :gameable, :user
   end
 

--- a/app/models/scorecard/progress.rb
+++ b/app/models/scorecard/progress.rb
@@ -3,7 +3,7 @@ class Scorecard::Progress < ActiveRecord::Base
 
   belongs_to :user,     polymorphic: true
 
-  if Rails.version.to_s < '4.0.0'
+  if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
     attr_accessible :identifier, :user
   end
 

--- a/app/models/scorecard/user_badge.rb
+++ b/app/models/scorecard/user_badge.rb
@@ -4,7 +4,7 @@ class Scorecard::UserBadge < ActiveRecord::Base
   belongs_to :user,     polymorphic: true
   belongs_to :gameable, polymorphic: true
 
-  if Rails.version.to_s < '4.0.0'
+  if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
     attr_accessible :badge, :identifier, :gameable, :user
   end
 


### PR DESCRIPTION
When a user has `protected_attributes`, the `attr_accessible` lines are still removed.
